### PR TITLE
用户可以决定导出到aria2失败后，是否由浏览器下载

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -32,6 +32,9 @@
    "allowExternalRequestDes":{
       "message":"Receive download request from other extension"
    },
+   "captureFailUseExplorerDes":{
+      "message":"Download with browser if export to Aria2 fails"
+   },
    "monitorAria2Str":{
       "message":"Monitor Aria2 Status"
    },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -32,6 +32,9 @@
    "allowExternalRequestDes":{
       "message":"他の拡張機能からのダウンロードリクエストを受信する"
    },
+   "captureFailUseExplorerDes":{
+      "message":"Aria2 へのエクスポートに失敗した場合はブラウザでダウンロード"
+   },
    "monitorAria2Str":{
       "message":"Aria 2状態の監視"
    },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -32,6 +32,9 @@
    "allowExternalRequestDes": {
       "message": "다른 확장으로부터 다운로드 요청 수락"
    },
+   "captureFailUseExplorerDes":{
+      "message":"Aria2로 내보내기 실패 시 브라우저로 다운로드"
+   },
    "monitorAria2Str": {
       "message": "Aria2 상태 모니터링"
    },

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -32,6 +32,9 @@
    "allowExternalRequestDes": {
       "message": "Отримуйте запит на завантаження з іншого розширення"
    },
+   "captureFailUseExplorerDes":{
+      "message":"Завантажте за допомогою браузера, якщо не вдалося експортувати в Aria2"
+   },
    "monitorAria2Str": {
       "message": "Монітор стану Aria2"
    },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -4,7 +4,7 @@
    },
    "description": {
       "message":"让Aria2无缝接管下载，加速下载体验，内置Aria2前端，任务管理更方便。"
-   }, 
+   },
    "contextmenuTitle":{
       "message":"导出到 "
    },
@@ -31,6 +31,9 @@
    },
    "allowExternalRequestDes":{
       "message":"接受来自其他扩展的下载请求"
+   },
+   "captureFailUseExplorerDes":{
+      "message":"如果导出到Aria2失败用浏览器下载"
    },
    "monitorAria2Str":{
       "message":"监测Aria2状态"

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -32,6 +32,9 @@
    "allowExternalRequestDes":{
       "message":"接受來自其他擴充功能的下載請求"
    },
+   "captureFailUseExplorerDes":{
+      "message":"如果導出到Aria2失敗用瀏覽器下載"
+   },
    "monitorAria2Str":{
       "message":"監測Aria2狀態"
    },

--- a/background.js
+++ b/background.js
@@ -191,8 +191,19 @@ async function captureDownload(downloadItem, suggest) {
             let rpcItem = getRpcServer(downloadItem.url);
             let ret = await send2Aria(rpcItem, downloadItem);
             if (ret == "FAIL") {
-                disableCapture();
-                chrome.downloads.download({ url: downloadItem.url }).then(enableCapture);
+                if (Configs.captureFailUseExplorer) {
+                    disableCapture();
+                    chrome.downloads.download({ url: downloadItem.url }).then(enableCapture);
+                } else {
+                    // 如果发送任务给aria2出错, 向用户报错
+                    let title = chrome.i18n.getMessage("taskNotification");
+                    let sign = ' ❌';
+                    const message = chrome.i18n.getMessage("downloadError", RemoteAria2.name) + sign;
+                    let id = "TaskStatus";
+                    let silent = Configs.keepSilent;
+                    let contextMessage = downloadItem.url
+                    Utils.showNotification({ title, message, contextMessage, silent }, id);
+                }
             }
         }
     }

--- a/js/config.js
+++ b/js/config.js
@@ -6,6 +6,7 @@ const Configs = {
     fileSize: "100",
     askBeforeDownload: false,
     allowExternalRequest: false,
+    captureFailUseExplorer: false,
     monitorAria2: false,
     keepAwake: false,
     allowNotification: false,

--- a/options.html
+++ b/options.html
@@ -69,6 +69,12 @@
               __MSG_captureMagnetDes__ <em>(__MSG_captureMagnetWarn__)</em>
             </label>
           </div>
+          <div class="custom-control custom-switch">
+            <input class="custom-control-input" type="checkbox" id="captureFailUseExplorer">
+            <label class="custom-control-label" for="captureFailUseExplorer">
+              __MSG_captureFailUseExplorerDes__
+            </label>
+          </div>
         </div>
       </div>
       <div class="form-group row">


### PR DESCRIPTION
我的aria2服务器放在外网的远程上面，每次导出失败都会使用本地浏览器下载，这不是我希望的，所以增加了一个选项，由用户决定是否失败后使用本地浏览器下载。
<img width="1028" alt="image" src="https://user-images.githubusercontent.com/26791215/233632792-315b2136-3f2e-4287-b6a1-9fa67edefdcd.png">

如果不启用，失败后提示用户下载失败；如果启用，失败后用本地浏览器下载。